### PR TITLE
fix asserts

### DIFF
--- a/src/test/java/UserServiceTest.java
+++ b/src/test/java/UserServiceTest.java
@@ -43,13 +43,9 @@ public class UserServiceTest {
 
             User user = userService.getAllUsers().get(0);
 
-            if (!testName.equals(user.getName())
-                    || !testLastName.equals(user.getLastName())
-                    || testAge != user.getAge()
-            ) {
-                Assert.fail("User был некорректно добавлен в базу данных");
-            }
-
+            Assert.assertEquals("User был некорректно добавлен в базу данных: не совпадает Name", testName, user.getName());
+            Assert.assertEquals("User был некорректно добавлен в базу данных: не совпадает LastName", testLastName, user.getLastName());
+            Assert.assertEquals("User был некорректно добавлен в базу данных: не совпадает Age", testAge, (byte) user.getAge());
         } catch (Exception e) {
             Assert.fail("Во время тестирования сохранения пользователя произошло исключение\n" + e);
         }
@@ -75,9 +71,7 @@ public class UserServiceTest {
             userService.saveUser(testName, testLastName, testAge);
             List<User> userList = userService.getAllUsers();
 
-            if (userList.size() != 1) {
-                Assert.fail("Проверьте корректность работы метода сохранения пользователя/удаления или создания таблицы");
-            }
+            Assert.assertEquals("Проверьте корректность работы метода сохранения пользователя/удаления или создания таблицы", 1, userList.size());
         } catch (Exception e) {
             Assert.fail("При попытке достать всех пользователей из базы данных произошло исключение\n" + e);
         }
@@ -91,9 +85,7 @@ public class UserServiceTest {
             userService.saveUser(testName, testLastName, testAge);
             userService.cleanUsersTable();
 
-            if (userService.getAllUsers().size() != 0) {
-                Assert.fail("Метод очищения таблицы пользователей реализован не корректно");
-            }
+            Assert.assertTrue("Метод очищения таблицы пользователей реализован не корректно", userService.getAllUsers().isEmpty());
         } catch (Exception e) {
             Assert.fail("При тестировании очистки таблицы пользователей произошло исключение\n" + e);
         }


### PR DESCRIPTION
- `src/test/java/UserServiceTest.java:46`  
В идеале лучше настаивать на переопределении `equals()` и `hashCode()` с учетом того, что `User` это сущность БД.  
Но если пошли _иным путём_, то пускай хоть точечно выявляется проблема.

- `src/test/java/UserServiceTest.java:74`, `src/test/java/UserServiceTest.java:88`  
Не стоит игнорировать предоставленные **jUnit4** разнообразие "асертов".